### PR TITLE
Fix exrm release error by adding exjsx as an application dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Mandrill.Mixfile do
 
   def application do
     [ mod: { Mandrill, [] },
-      applications: [:httpoison] ]
+      applications: [:httpoison, :exjsx] ]
   end
 
   defp deps do


### PR DESCRIPTION
The error do not appear locally, neither on basic heroku setups, but it do not ship `exjsx` correctly when packaging the app using `exrm` on `mix release`

error details:
```
** (exit) an exception was raised:
   ** (UndefinedFunctionError) undefined function: JSX.encode!/1 (module JSX is not available)
       JSX.encode!([key: nil, message: [html: " ...
 (mandrill) lib/mandrill.ex:42: Mandrill.request/2
```