### PR TITLE
return param keys as strings

### DIFF
--- a/lib/mandrill.ex
+++ b/lib/mandrill.ex
@@ -22,13 +22,13 @@ defmodule Mandrill do
   end
 
   @doc """
-  Converts the binary keys in our response to atoms.
+  Converts the binary keys in our response to strings.
   Args:
     * body - string binary response
   Returns Record or ArgumentError
   """
   def process_response_body(body) do
-    JSX.decode!(body, [{:labels, :atom}])
+    JSX.decode!(body)
   end
 
   @doc """

--- a/test/mandrill_test.exs
+++ b/test/mandrill_test.exs
@@ -9,4 +9,8 @@ defmodule MandrillTest do
   	Mandrill.start
   	assert Mandrill.Users.ping == "PONG!"
   end
+
+  test "process_response_body returns a map with string keys" do
+    assert Mandrill.process_response_body("{\"language\": \"elixir\", \"awesome\": true}") == %{"awesome" => true, "language" => "elixir"}
+  end
 end


### PR DESCRIPTION
Converting external parameters from strings keys to atom keys creates the vulnerability of being susceptible to a DoS attack, via object allocation. With this in mind, I'm proposing that we remove the string-to-atom conversion that's currently taking place.

I realize this will introduce a breaking change. If you like, I'm happy to bump the version as well.
